### PR TITLE
Fix stack overflow with tail-end optimization

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -44,7 +44,18 @@ fn usz(i: isize) -> usize {
     i as usize
 }
 
-fn split(I: &mut [isize], V: &mut [isize], start: usize, len: usize, h: usize) {
+struct SplitParams {
+    start: usize,
+    len: usize,
+}
+
+fn split_internal(
+    I: &mut [isize],
+    V: &mut [isize],
+    start: usize,
+    len: usize,
+    h: usize,
+) -> Option<SplitParams> {
     if len < 16 {
         let mut k = start;
         while k < start + len {
@@ -70,6 +81,8 @@ fn split(I: &mut [isize], V: &mut [isize], start: usize, len: usize, h: usize) {
             }
             k += j;
         }
+
+        None
     } else {
         let x = V[usz(I[start + len / 2] + h as isize)];
         let mut jj = 0;
@@ -116,9 +129,22 @@ fn split(I: &mut [isize], V: &mut [isize], start: usize, len: usize, h: usize) {
         if jj == kk - 1 {
             I[jj] = -1;
         }
+
         if start + len > kk {
-            split(I, V, kk, start + len - kk, h);
+            Some(SplitParams {
+                start: kk,
+                len: start + len - kk,
+            })
+        } else {
+            None
         }
+    }
+}
+
+fn split(I: &mut [isize], V: &mut [isize], start: usize, len: usize, h: usize) {
+    let mut ret = Some(SplitParams { start, len });
+    while let Some(params) = ret {
+        ret = split_internal(I, V, params.start, params.len, h);
     }
 }
 


### PR DESCRIPTION
(Hi there, this is my first pull request to this repository. I noticed that rust format messes with the format a bit, I'm not sure if it's because rust official formatting has changed or because this repository isn't formatted, but I only included the relevant change for now rather than any formatting changes)

The `split()` function is designed to use recursion, but in certain cases -- such as if the only differing data is near the end of a large amount of data while using a debug build -- it can cause a stack overflow, particularly with the second recursive split() call. The reason this seems to happen in Rust and not the C version is because Rust debug builds appear to use a significantly larger amount of stack space per function call. As it is, this function is unusable when used with very large files while building debug.

This change adds a tail-end optimization and significantly reduces recursion. It's probably also more optimal. It's only second recursion call, but it's probably the more important case.

If you'd like me to show you how to reproduce this issue, please let me know. I encountered the stack overflow when performing a diff on two binary dynamic link library files, and I'd rather not post dynamic link library files on here or anything.

As a bit of a short summary, basically the recursion is just causing crashes on debug builds because the function uses too much stack space in debug rust. This just fixes it by making it avoid some (but not all) recursion.