### PR TITLE
support generic output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ repository = "https://github.com/space-wizards/bsdiff-rs"
 edition = "2021"
 include = ["src/*.rs", "LICENSE", "README.md", "Cargo.toml"]
 rust-version = "1.59"
+
+[dev-dependencies]
+smallvec = { version = "1.15.0", features = ["write"] }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -47,8 +47,7 @@ use std::io::Write;
 ///
 /// ```rust
 /// use bsdiff::{diff, patch};
-/// use std::io::Cursor;
-///
+/// 
 /// // Create some test data
 /// let old_data = b"Hello, world!";
 /// let new_data = b"Hello, Rust!";


### PR DESCRIPTION
## 📦 PR: Generalize `patch` output buffer to support `AlignedVec` and other custom writers

### ✨ Summary

This PR generalizes the `patch` function’s output buffer parameter (`new`) from a fixed `&mut Vec<u8>` to any type that implements:

- `std::io::Write` — for writing patch data,
- `DerefMut<Target = [u8]>` — for in-place mutation of the diff section.

This allows the function to be used with buffer types like [`AlignedVec`](https://docs.rs/rkyv/latest/rkyv/util/struct.AlignedVec.html), which provide memory alignment guarantees required for later reinterpretation (e.g., casting to typed data).

---

### 🧪 What Changed

- **Signature change**:  
  ```rust
  - pub fn patch<T: Read>(..., new: &mut Vec<u8>)
  + pub fn patch<T: Read, W: Write + DerefMut<Target = [u8]>>(..., new: &mut W)
  
### ⚠️ Breaking Change: Type Inference
```rust
let mut buf = Default::default();
patch(old, &mut patch_data, &mut buf); // ❌ may fail to infer `Vec<u8>`
```
Developers may now need to explicitly specify the type:
```rust
let mut buf: Vec<u8> = Default::default();
```

✅ Benefits
- Supports memory-aligned buffers like AlignedVec.
- Enables more flexible and performant downstream use cases (e.g., reinterpreting as typed memory).
- Maintains all behavior of the original patch logic.


Let me know if you want a version with a fallback function to keep compatibility for existing callers.

